### PR TITLE
Create activity_chart_selector

### DIFF
--- a/user-submitted/ui-scripts/activity_chart_selector
+++ b/user-submitted/ui-scripts/activity_chart_selector
@@ -2,7 +2,7 @@ name: Hide/Show statuses activity charts
 description: Allows to hide/show statuses on an activity chart, by clicking on status titles.
 author: Romain TAPREST, Gabriel HENRY
 version: 1.0
-includes: ^(projects/overview|cases/results/.*|runs/activity/.*)
+includes: ^(projects/overview|cases/results/.*|runs/activity/.*|plans/activity/.*)
 excludes: 
 
 js:

--- a/user-submitted/ui-scripts/activity_chart_selector
+++ b/user-submitted/ui-scripts/activity_chart_selector
@@ -1,0 +1,28 @@
+name: Hide/Show statuses activity charts
+description: Allows to hide/show statuses on an activity chart, by clicking on status titles.
+author: Romain TAPREST, Gabriel Henry
+version: 1.0
+includes: ^(projects/overview|cases/results/.*|runs/activity/.*)
+excludes: 
+
+js:
+$(document).ready(
+    function () {
+        $(".chart-legend-item").each(function () {
+            $(this).hover(function() {
+                $(this).css('cursor','pointer');
+            });
+            $(this).click(function(){ 
+                let name = $(this).children().find(".chart-legend-name").text().split(" ").slice(1).join(" ");
+                let serie = App.Charts.activity.series.find(serie => serie.name == name);
+                if (serie.visible) {
+                    serie.hide();
+                    $(this).wrap("<del>");
+                } else {
+                    serie.show();
+                    $(this).unwrap("<del>");
+                }
+             });
+        })
+    }
+);

--- a/user-submitted/ui-scripts/activity_chart_selector
+++ b/user-submitted/ui-scripts/activity_chart_selector
@@ -1,6 +1,6 @@
 name: Hide/Show statuses activity charts
 description: Allows to hide/show statuses on an activity chart, by clicking on status titles.
-author: Romain TAPREST, Gabriel Henry
+author: Romain TAPREST, Gabriel HENRY
 version: 1.0
 includes: ^(projects/overview|cases/results/.*|runs/activity/.*)
 excludes: 


### PR DESCRIPTION
This UI script add a functionality to any activity chart (displaying test statuses). It allows to hide any status from the chart. That is useful because some curves can hide others when they overlap or when values are too high. User must click on a status (on the right side). Clicking again unhide it.